### PR TITLE
fix(far): drop Copy from TopologyDescriptor (consuming-builder footgun)

### DIFF
--- a/opensubdiv-petite/src/far/topology_descriptor.rs
+++ b/opensubdiv-petite/src/far/topology_descriptor.rs
@@ -60,7 +60,14 @@ use std::marker::PhantomData;
 ///
 /// See the [module level documentation](crate::far::topology_descriptor) for
 /// an example.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+// NOT `Copy`: `creases`/`corners` are consuming builders (`mut self ->
+// Result<Self>`). With `Copy`, a bare `descriptor.creases(..)` would
+// mutate a discarded copy and silently drop the creases while the
+// original stays usable -- a latent footgun that already caused a
+// silent oracle regression downstream. Without `Copy`, that misuse is a
+// `use-after-move` compile error; the correct `descriptor =
+// descriptor.creases(..)?` pattern is unaffected.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct TopologyDescriptor<'a> {
     pub(crate) descriptor: sys::OpenSubdiv_v3_7_0_Far_TopologyDescriptor,
     // _marker needs to be invariant in 'a.


### PR DESCRIPTION
## Summary

Removes `Copy` from `far::TopologyDescriptor` (keeps `Clone`).

`TopologyDescriptor::{creases, corners}` are *consuming* builders (`mut self -> Result<Self>`). While the type was `Copy`, the natural-looking in-place form

```rust
let mut descriptor = far::TopologyDescriptor::new(..)?;
descriptor.creases(&idx, &sharp);          // return value discarded!
let refiner = far::TopologyRefiner::new(descriptor, opts)?;  // creaseless
```

silently mutated a **throwaway copy** and fed the original, creaseless descriptor to the refiner — only a `must_use` warning fired. Without `Copy`, that misuse is now a hard `error[E0382]: use of moved value` at compile time. The correct chained form (`descriptor = descriptor.creases(..)?`) is unaffected.

This fixes the silent-crease-drop class of bug observed downstream (`subdiv-kernels`' OpenSubdiv limit-oracle suite was comparing a correctly-creased surface against a smooth one for months).

## Why it's safe

- Every consumer in this repo already uses the consuming builder correctly (`descriptor = descriptor.creases(..)?`); none rely on `Copy`.
- `TopologyRefiner::new(descriptor, ..)` takes the descriptor by value and never reuses it; no `Copy` bound exists anywhere on the type.
- `cargo build -p opensubdiv-petite` (lib) and the `far::topology_descriptor` doctest are green.

It is a technically breaking public-API change (removing a trait from a public type), but the only known consumers are owned by the same author and none depend on `Copy`.
