### PR TITLE
fix(sys): MSVC-compatible osd-capi build for Windows (supersedes #7)

### DIFF
--- a/opensubdiv-petite-sys/build.rs
+++ b/opensubdiv-petite-sys/build.rs
@@ -125,8 +125,15 @@ pub fn main() {
         .include(&osd_inlude_path)
         .include("OpenSubdiv") // Add source directory for headers like patchBasis.h
         .cpp(true)
-        .flag("-std=c++14")
-        .flag("-Wno-return-type-c-linkage")
+        // `.std()` emits `-std=c++14` for clang/gcc and `/std:c++14` for MSVC.
+        .std("c++14")
+        // MSVC's `<cmath>` only defines `M_PI` and friends when this is set;
+        // the transitively-included OpenSubdiv headers rely on them. Defining
+        // it on clang/gcc is harmless.
+        .define("_USE_MATH_DEFINES", None)
+        // `-Wno-return-type-c-linkage` is a clang/gcc warning flag; MSVC does
+        // not understand it, so only pass it where the compiler accepts it.
+        .flag_if_supported("-Wno-return-type-c-linkage")
         .file("c-api/far/primvar_refiner.cpp")
         .file("c-api/far/stencil_table.cpp")
         .file("c-api/far/stencil_table_factory.cpp")


### PR DESCRIPTION
Reworks the still-relevant Windows build fixes from #7 onto the current build system.

## Context

#7 ("Make opensubdiv-petite work in windows") can't be merged directly: it predates the `opensubdiv` → `opensubdiv-petite` crate rename and targets OpenSubdiv **v3.4.4**, whereas `master` is on **v3.7.0** with a fully rewritten `build.rs`. Its diff is dominated by rename noise.

Two distinct fixes lived in #7:

1. **bindgen enum int/uint** ([rust-bindgen#1966](https://github.com/rust-lang/rust-bindgen/issues/1966)) — MSVC types unscoped enums as `i32`, clang/Linux as `u32`. This is **already handled on master**: enum constants are cast with `as _` (e.g. `CatmullClark = ...SCHEME_CATMARK as _`), which coerces to the enum repr regardless of signedness. Nothing to do.
2. **C++ build flags for MSVC** — reapplied here.

## Changes (`opensubdiv-petite-sys/build.rs`, osd-capi cc build)

- `.std("c++14")` instead of `.flag("-std=c++14")` — emits `/std:c++14` on MSVC, `-std=c++14` elsewhere.
- Define `_USE_MATH_DEFINES` so MSVC's `<cmath>` exposes `M_PI` etc. to the transitively-included OpenSubdiv headers.
- Pass `-Wno-return-type-c-linkage` via `flag_if_supported` so MSVC (which rejects it) skips it.

No `Cargo.toml` change is needed (#7's `regex` Windows build-dep was only for its old build.rs), and no Windows link branch is needed (MSVC auto-links the CRT; the `linux`/`macos` branches correctly no-op).

## Testing

Verified still building on Linux. **Windows is not yet validated** — needs a Windows CI run (no Windows runner is set up in this repo yet). Treat as best-effort until CI is green.