### PR TITLE
docs: drop stale TODOs for implemented backends (Metal, OpenCL, PatchTable)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,8 @@ This is a "petite" wrapper -- it doesn't expose the entire OpenSubdiv API. Focus
 
 - `topology_validation` -- Enable expensive validation (default on).
 - `cuda` -- NVIDIA CUDA backend support.
-- `metal` -- Apple Metal backend (TODO).
-- `opencl` -- OpenCL backend (TODO).
+- `metal` -- Apple Metal backend.
+- `opencl` -- OpenCL backend.
 - `ptex` -- PTex texture support (TODO).
 - `tri_mesh_buffers` -- Integration with mesh buffer types.
 
@@ -186,9 +186,6 @@ fd "\.rs$"
 
 ## Known Issues and TODOs
 
-- [ ] PatchTable support not yet implemented.
-- [ ] Metal backend pending implementation.
-- [ ] OpenCL backend pending implementation.
 - [ ] PTex support pending implementation.
 - [ ] OpenMP detection broken on macOS.
 - [ ] CUDA build configuration needs automation.


### PR DESCRIPTION
`AGENTS.md` still flagged Metal, OpenCL, and PatchTable as unimplemented, but all three have full implementations on `master`:

- **Metal** — `src/osd/metal_{evaluator,vertex_buffer}.rs` + `c-api/osd/metal_*.cpp`, behind `--features metal`
- **OpenCL** — `src/osd/opencl_{evaluator,vertex_buffer}.rs` + `c-api/osd/opencl_*.cpp`, behind `--features opencl`
- **PatchTable** — `src/far/patch_table.rs` (685 LOC) + `c-api/far/patch_table.cpp`, with examples

Removes their `(TODO)` / "pending implementation" markers from the feature-flag list and the Known Issues section. Complements closing #3 (Add Metal support).

Left untouched because they remain genuine TODOs: PTex, OpenMP-on-macOS (#2), and CUDA build automation.